### PR TITLE
Fix note color persistence

### DIFF
--- a/script.js
+++ b/script.js
@@ -100,7 +100,6 @@
         renderNotes();
         updateTagFilterUI();
         setupEventListeners();
-        setupAutoSave();
 
         notes.forEach((note) => {
           if (note.reminderAt && note.reminderAt > Date.now()) {
@@ -459,14 +458,6 @@
           btn.addEventListener("click", () => {
             currentNote.color = btn.dataset.color;
             updateColorButtons();
-            if (currentNote.id) {
-              currentNote.updatedAt = Date.now();
-              saveNoteToDb({ ...currentNote }).then(() => {
-                const idx = notes.findIndex((n) => n.id === currentNote.id);
-                if (idx >= 0) notes[idx] = { ...currentNote };
-                renderNotes();
-              });
-            }
           });
         });
 
@@ -556,7 +547,7 @@
       // Modal functions
       function openNoteModal(type, noteId = null) {
         currentNote = noteId
-          ? notes.find((n) => n.id === noteId)
+          ? { ...notes.find((n) => n.id === noteId) }
           : { type: type, tags: [], isFavorite: false, createdAt: Date.now(), color: "default" };
 
         currentNote.color = currentNote.color || "default";


### PR DESCRIPTION
## Summary
- ensure color changes don't auto-save while editing
- copy note before editing to avoid mutating stored notes
- remove call to automatic save on edit

## Testing
- `bash -lc 'npm test'` *(fails: no such script)*