### PR TITLE
Add divider between pinned and normal notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
             class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-6"
           ></div>
         </div>
+        <div id="notes-divider" class="border-t border-light-outline dark:border-dark-outline my-6 hidden"></div>
         <div
           id="notes-container"
           class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 md:gap-6"

--- a/js/app.js
+++ b/js/app.js
@@ -131,6 +131,7 @@
         const container = document.getElementById("notes-container");
         const pinnedContainer = document.getElementById("pinned-notes-container");
         const pinnedSection = document.getElementById("pinned-section");
+        const divider = document.getElementById("notes-divider");
         const emptyState = document.getElementById("empty-state");
         const filteredNotes = filterNotes();
 
@@ -140,6 +141,7 @@
         if (filteredNotes.length === 0) {
           container.innerHTML = "";
           pinnedContainer.innerHTML = "";
+          divider.classList.add("hidden");
           container.classList.remove(
             "sm:grid-cols-2",
             "lg:grid-cols-3",
@@ -167,6 +169,10 @@
             "xl:grid-cols-4"
           );
           pinnedSection.classList.toggle("hidden", pinned.length === 0);
+          divider.classList.toggle(
+            "hidden",
+            pinned.length === 0 || others.length === 0
+          );
           pinnedContainer.innerHTML = pinned
             .map((note) => createNoteCard(note))
             .join("");


### PR DESCRIPTION
## Summary
- insert a divider element in the layout
- toggle divider visibility in `renderNotes`

## Testing
- `npm test` *(fails: no `package.json`)*