### PR TITLE
Add list/grid view toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,10 @@
       <header class="sticky top-0 z-50 w-full bg-light-surface dark:bg-dark-surface p-4 shadow-md flex justify-center">
         <div class="relative w-full max-w-3xl">
           <span class="material-symbols-outlined absolute inset-y-0 left-3 flex items-center pointer-events-none text-light-on-surface-variant dark:text-dark-on-surface-variant">search</span>
-          <input type="text" id="search-input" placeholder="Szukaj..." class="w-full pl-10 pr-3 py-2.5 text-sm bg-light-surface-variant dark:bg-dark-surface-variant border-none rounded-full focus:ring-2 focus:ring-light-primary dark:focus:ring-dark-primary text-light-on-surface dark:text-dark-on-surface placeholder-light-on-surface-variant dark:placeholder-dark-on-surface-variant" />
+          <input type="text" id="search-input" placeholder="Szukaj..." class="w-full pl-10 pr-10 py-2.5 text-sm bg-light-surface-variant dark:bg-dark-surface-variant border-none rounded-full focus:ring-2 focus:ring-light-primary dark:focus:ring-dark-primary text-light-on-surface dark:text-dark-on-surface placeholder-light-on-surface-variant dark:placeholder-dark-on-surface-variant" />
+          <button id="view-toggle" type="button" class="absolute inset-y-0 right-3 flex items-center p-1.5 rounded-full text-light-on-surface-variant dark:text-dark-on-surface-variant hover:bg-light-surface-variant dark:hover:bg-dark-surface-variant">
+            <span class="material-symbols-outlined">view_agenda</span>
+          </button>
           <div id="search-suggestions" class="absolute left-0 right-0 mt-1 bg-light-surface dark:bg-dark-surface border border-light-outline dark:border-dark-outline rounded-lg shadow-lg text-sm hidden max-h-60 overflow-y-auto z-50"></div>
         </div>
       </header>

--- a/js/app.js
+++ b/js/app.js
@@ -8,12 +8,14 @@
       let recordingStartTime = 0;
       let recordingTimerInterval = null;
       let isDarkMode = false;
+      let isGridView = true;
 
       // DOM Elements
       const noteModal = document.getElementById("note-modal");
       const confirmModal = document.getElementById("confirm-modal");
       const themeToggleButton = document.getElementById("theme-toggle");
       const themeToggleText = document.getElementById("theme-toggle-text");
+      const viewToggleButton = document.getElementById("view-toggle");
       const favoriteCheckbox = document.getElementById("note-favorite");
       const pinnedCheckbox = document.getElementById("note-pinned");
       const colorButtons = document.querySelectorAll(
@@ -158,16 +160,29 @@
         } else {
           emptyState.classList.add("hidden");
           emptyState.classList.remove("flex");
-          container.classList.add(
-            "sm:grid-cols-2",
-            "lg:grid-cols-3",
-            "xl:grid-cols-4"
-          );
-          pinnedContainer.classList.add(
-            "sm:grid-cols-2",
-            "lg:grid-cols-3",
-            "xl:grid-cols-4"
-          );
+          if (isGridView) {
+            container.classList.add(
+              "sm:grid-cols-2",
+              "lg:grid-cols-3",
+              "xl:grid-cols-4"
+            );
+            pinnedContainer.classList.add(
+              "sm:grid-cols-2",
+              "lg:grid-cols-3",
+              "xl:grid-cols-4"
+            );
+          } else {
+            container.classList.remove(
+              "sm:grid-cols-2",
+              "lg:grid-cols-3",
+              "xl:grid-cols-4"
+            );
+            pinnedContainer.classList.remove(
+              "sm:grid-cols-2",
+              "lg:grid-cols-3",
+              "xl:grid-cols-4"
+            );
+          }
           pinnedSection.classList.toggle("hidden", pinned.length === 0);
           divider.classList.toggle(
             "hidden",
@@ -463,6 +478,7 @@
           .addEventListener("click", executeDeleteNote);
 
         themeToggleButton.addEventListener("click", toggleTheme);
+        viewToggleButton.addEventListener("click", toggleView);
 
         noteModal.addEventListener("click", (e) => {
           if (e.target === noteModal) closeNoteModal();
@@ -1121,6 +1137,18 @@
         localStorage.setItem("notesAppThemeM3", isDarkMode ? "dark" : "light");
       }
 
+      function toggleView() {
+        isGridView = !isGridView;
+        updateViewIcon();
+        localStorage.setItem("notesViewMode", isGridView ? "grid" : "list");
+        renderNotes();
+      }
+
+      function updateViewIcon() {
+        const icon = viewToggleButton.querySelector(".material-symbols-outlined");
+        icon.textContent = isGridView ? "view_agenda" : "grid_view";
+      }
+
       function loadPreferences() {
         const savedTheme = localStorage.getItem("notesAppThemeM3");
         const themeIcon = themeToggleButton.querySelector(
@@ -1143,6 +1171,10 @@
           themeIcon.textContent = "dark_mode";
           themeToggleText.textContent = "Ciemny motyw";
         }
+
+        const savedView = localStorage.getItem("notesViewMode");
+        isGridView = savedView ? savedView === "grid" : true;
+        updateViewIcon();
       }
 
       // Toast notifications


### PR DESCRIPTION
## Summary
- add grid/list switch next to search bar
- support storing view choice in local storage
- adjust note rendering to respect the chosen view

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`